### PR TITLE
Fixed missing file extension after tsc

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -3,7 +3,7 @@ import { ModelProviderName } from "@elizaos/core";
 import { AgentRuntime } from "@elizaos/core";
 import Database from "better-sqlite3";
 import { SqliteDatabaseAdapter } from "@elizaos/adapter-sqlite";
-import { editFileAction } from "./actionManager";
+import { editFileAction } from "./actionManager.js";
 
 export const setupAgent = (codebase: any): AgentRuntime => {
   const character: Character = {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,8 +3,8 @@ import ora from "ora";
 
 import { AgentRuntime, generateText, ModelClass } from "@elizaos/core";
 import chalk from "chalk";
-import { Codebase } from "./scanner";
-import { LLMAction, actions, editFileAction } from "./actionManager";
+import { Codebase } from "./scanner.js";
+import { LLMAction, actions, editFileAction } from "./actionManager.js";
 
 export const startCLI = (agent: AgentRuntime, codebase: Codebase) => {
   const rl = createCLIInterface();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { AgentRuntime } from "@elizaos/core";
-import { setupAgent } from "./agent";
-import { startCLI } from "./cli";
-import { scanCodebase } from "./scanner";
+import { setupAgent } from "./agent.js";
+import { startCLI } from "./cli.js";
+import { scanCodebase } from "./scanner.js";
 
 export const setupCodeAssistant = async (projectPath: string) => {
   const agent = setupAgent("");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "esModuleInterop": true,
     "outDir": "./dist",
     "rootDir": "./src",
@@ -16,6 +16,11 @@
     "moduleDetection": "force",
     "allowSyntheticDefaultImports": true
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }


### PR DESCRIPTION
# Описание
Модуль система изменена на `nodenext` которая обязывает `tsc` сохранить расширения `.js` для модулей после компиляции.

# Решаемые проблемы

Топик: [TypeScript: Compiled JavaScript import is missing file extension](https://github.com/microsoft/TypeScript/issues/40878)
Солюшен: [Решение с nodenext](https://github.com/microsoft/TypeScript/issues/52412#issuecomment-1403785702)

# Изменения

- В `tsconfig.json` обновил модульную систему на `nodenext`
- Теперь компилятор обязывает проставить расширения для импортов в `.ts` файлах.
- Итого: импортированые модули сохраняют свое расширение в `dist/`  и теперь не нужно будет проставлять `.js` каждый раз после компиляции `tsc`.
