### PR TITLE
feat: add helper fix imports after compile tsc

### DIFF
--- a/_helper/fixImports.js
+++ b/_helper/fixImports.js
@@ -1,0 +1,46 @@
+import { promises } from "fs";
+import { join } from "path";
+import chalk from "chalk";
+
+const outDir = "./dist";
+
+async function fixImports(filePath) {
+  try {
+    let content = await promises.readFile(filePath, "utf8");
+    content = content.replace(/from\s+["'](\..+?)["']/g, 'from "$1.js"');
+    await promises.writeFile(filePath, content, "utf8");
+
+    console.log(chalk.green(`✅ Fixed imports in: ${filePath}`));
+  } catch (error) {
+    console.log(chalk.red(`❌ Error processing file ${filePath}:`, error));
+  }
+}
+
+async function processDirectory(dir) {
+  try {
+    const files = await promises.readdir(dir, { withFileTypes: true });
+
+    for (const file of files) {
+      const fullPath = join(dir, file.name);
+
+      if (file.isDirectory()) {
+        await processDirectory(fullPath);
+      } else if (file.name.endsWith(".js")) {
+        await fixImports(fullPath);
+      }
+    }
+  } catch (error) {
+    console.log(chalk.red(`❌ Error processing directory ${dir}:`, error));
+  }
+}
+
+(async () => {
+  try {
+    console.log(chalk.yellow("🚀 Starting import fix..."));
+    await processDirectory(outDir);
+    console.log(chalk.yellow("🎉 Import fix completed"));
+  } catch (error) {
+    console.log(chalk.red("❌ Critical error::", error));
+    process.exit(1);
+  }
+})();

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "tsc && node _helper/fixImports.js"
   },
   "bin": {
     "guidedao-code": "./bin/guidedao-code.js"


### PR DESCRIPTION
# 🚀 Fix Imports in `.js` Files

### 🔄 How It Works
1. **Compilation:** TypeScript compiles the project using `tsc`, generating `.js` files in the `dist/` directory.
2. **Import Fixing:** After compilation, a script scans all `.js` files and modifies `import` statements to append `.js` where necessary.
3. **Ready-to-Use:** The output in `dist/` is now properly formatted for ES module compatibility.

## 📌 What’s Changed?
- Updated `.js` files to append `.js` in `import` statements (`from "./example"` → `from "./example.js"`).
- Added support for nested directories.
- Improved error handling.
- **New workflow:** TypeScript compiles `.ts` files into `.js` using `tsc`, and then a helper script runs to fix imports.

## 🛠 How to Test?
1. Run `npm run start`, `yarn  start`, `pnpm start`
2. Check that all `.js` files in `dist/` have correct imports.

## ✅ Checklist
- [ ] Code has been tested.
- [x] Error handling is implemented.
- [x] Works with nested directories.